### PR TITLE
ci: fix formatting post template setup

### DIFF
--- a/DESIGN-GUIDE.md
+++ b/DESIGN-GUIDE.md
@@ -37,12 +37,12 @@ mkdir -p static/images
 
 ### **Step 2: Add These Images**
 
-| Filename                 | Purpose              | Recommended Theme               |
-| ------------------------ | -------------------- | ------------------------------- |
-| `hero-bg.jpg`            | Hero/Passcode page   | Coastal sunset, ocean waves     |
-| `rsvp-bg.jpg`            | RSVP form background | Soft beach, elegant texture     |
-| `wedding-details-bg.jpg` | Timeline section     | Scenic landscape, cliffs        |
-| `venue-bg.jpg`           | Venue info section   | Your venue or local scenery     |
+| Filename                 | Purpose              | Recommended Theme           |
+| ------------------------ | -------------------- | --------------------------- |
+| `hero-bg.jpg`            | Hero/Passcode page   | Coastal sunset, ocean waves |
+| `rsvp-bg.jpg`            | RSVP form background | Soft beach, elegant texture |
+| `wedding-details-bg.jpg` | Timeline section     | Scenic landscape, cliffs    |
+| `venue-bg.jpg`           | Venue info section   | Your venue or local scenery |
 
 ### **Step 3: Image Requirements**
 

--- a/README.md
+++ b/README.md
@@ -61,14 +61,16 @@ Visit [http://localhost:8888](http://localhost:8888)
 #### Background images
 
 > [!TIP]
-> * All images in `static/images` are currently placeholder images/duplicates.
-> * Replaces these with memorabale images that you'd like for your site.
+>
+> - All images in `static/images` are currently placeholder images/duplicates.
+> - Replaces these with memorabale images that you'd like for your site.
 
 #### Copy
 
 > [!WARNING]
-> * Currently all placeholder/dummy text
-> * Fill this out as you desire.
+>
+> - Currently all placeholder/dummy text
+> - Fill this out as you desire.
 
 #### Google Sheets RSVP
 
@@ -76,8 +78,9 @@ Visit [http://localhost:8888](http://localhost:8888)
 - To set this up properly.
 
 > [!NOTE]
-> * This is yet to be properly tested.
-> * Placeholder stubs for now. 
+>
+> - This is yet to be properly tested.
+> - Placeholder stubs for now.
 
 ## 🛠 Development Scripts
 
@@ -105,5 +108,6 @@ npm run deploy
 # 🚀 Deployment
 
 > [!WARNING]
-> * Again, currently in WIP format. 
-> * Yet to be deployed but should be straightforward.
+>
+> - Again, currently in WIP format.
+> - Yet to be deployed but should be straightforward.

--- a/SETUP.md
+++ b/SETUP.md
@@ -43,7 +43,7 @@ Visit: http://localhost:8888
 - [ ] Set `WEDDING_PASSCODE` in `.env`
 - [ ] Update all copy in `src/lib/content.ts` and `src/lib/constants.ts`
 - [ ] (Optional) Configure Google Sheets RSVP (see `google-apps-script.js`)
-    - See note in readme. Yet to be tested
+  - See note in readme. Yet to be tested
 
 ## Deploy to Netlify
 
@@ -79,9 +79,9 @@ When deploying to Netlify, you MUST set `WEDDING_PASSCODE` in the Netlify dashbo
 
 ### 📁 Local Documentation
 
-* Currently I set this up such that the `todo/` directory contains internal and non-committed documentation.
-* Use this if you require.
-* I used this to store generic notes that I did not want comitted.
+- Currently I set this up such that the `todo/` directory contains internal and non-committed documentation.
+- Use this if you require.
+- I used this to store generic notes that I did not want comitted.
 
 ## Troubleshooting
 

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -74,8 +74,7 @@ export const COPY = {
     features: {
       chapel: {
         title: 'The Ceremony Space',
-        description:
-          'Describe the main ceremony area and what guests can expect when they arrive.',
+        description: 'Describe the main ceremony area and what guests can expect when they arrive.',
       },
       views: {
         title: 'Scenic Views',


### PR DESCRIPTION
* Enables CI to pass.
* When porting over from private repo I forgot to format and lint on project.
* Fixes ci.
    * `npm run format`, `npm run lint`  and `npm run check` pass now