### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/format-check-lint.yml
+++ b/.github/workflows/format-check-lint.yml
@@ -53,7 +53,3 @@ jobs:
         run: npm audit --audit-level=moderate || true
       - name: Build (Vite)
         run: npm run build
-      - name: Deploy Preview (skeleton)
-        if: github.event_name == 'pull_request'
-        run: echo "Deploy preview step to run run here (e.g., through netlify CLI)"
-        # TODO: Implement actual deploy preview logic (e.g., netlify deploy --build --json)


### PR DESCRIPTION
# Autogenerated: Code Scan Fix

Potential fix for [https://github.com/jordyjwilliams/wedding-website-template/security/code-scanning/1](https://github.com/jordyjwilliams/wedding-website-template/security/code-scanning/1)

In general, to fix this issue you should explicitly declare a `permissions` block either at the top (workflow level, applying to all jobs) or within the specific job that needs the token, granting only the minimal scopes required. For this workflow, all steps are build/test-style operations and only need to read the repository contents; they do not need to write to the repository or manage issues, pull requests, etc. Thus, the least-privilege configuration is to set `contents: read`.

The best fix without changing existing functionality is to add a workflow-level `permissions` block right after the `on:` section (or, equivalently, a job-level block under `jobs.build`). A workflow-level block is simpler and documents that all jobs are limited to read-only repository access. Concretely, in `.github/workflows/format-check-lint.yml`, between the `on:` section (lines 6–10) and the `jobs:` key (line 12), insert:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed, since this is purely a configuration change to the GitHub Actions workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

# Additional: GitHub Actions Cleanup
* Removes Deploy step - automatically handled by netlify repo sync